### PR TITLE
Fix namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,13 @@
+# MARC::FastXMLWriter
+
+## 1.1.0 Fix namespace code
+
+The The supposed `include_namespace` code wasn't actually using
+the namespace (`xmlns="http://www.loc.gov/..."`), only 
+defining it (`xmlns:marc="http://www.loc.gov/...`), thus producing
+files were not, in fact, namespaced.
+
+Also adds tests against nokogiri as well as rexml
+
+### 1.0.0 First release
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in marc-fastxmlwriter.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -3,9 +3,9 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
-  t.pattern = 'test/**/*_spec.rb'
+  t.pattern = "test/**/*_spec.rb"
   t.libs << "test"
 end
 
-task :spec => :test
-task :default => :test
+task spec: :test
+task default: :test

--- a/lib/marc/fastxmlwriter.rb
+++ b/lib/marc/fastxmlwriter.rb
@@ -1,89 +1,82 @@
 require "marc/fastxmlwriter/version"
 
-require 'marc'
+require "marc"
 
 module MARC
   class FastXMLWriter < MARC::XMLWriter
-
     XML_HEADER = '<?xml version="1.0" encoding="UTF-8"?>'
-    
-    
-    OPEN_COLLECTION = "<collection">
-    OPEN_COLLECTION_NAMESPACE = %Q{<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">}
-  
-    
-    def initialize(file, opts={})
+
+    OPEN_COLLECTION = "<collection>"
+    OPEN_COLLECTION_NAMESPACE = %(<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">)
+
+    def initialize(file, opts = {})
       super
-    end     
-    
+    end
+
     def write(record)
       @fh.write(self.class.encode(record))
       # @fh.write("\n")
     end
-    
+
     class << self
-            
       def open_collection(use_ns)
         if use_ns
-          %Q{<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:marc="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">}.dup
+          OPEN_COLLECTION_NAMESPACE.dup
         else
-          "<collection>".dup
+          OPEN_COLLECTION.dup
         end
       end
-        
-      
-      def single_record_document(r, opts={})
-        
+
+      def single_record_document(r, include_namespace: true)
         xml = XML_HEADER.dup
-        xml << open_collection(opts[:include_namespace])
-        xml << encode(r, opts)
-        xml << '</collection>'
+        xml << open_collection(include_namespace)
+        xml << encode(r)
+        xml << "</collection>"
         xml
       end
-      
+
       def open_datafield(tag, ind1, ind2)
-        # return "\n  <datafield tag=\"#{tag}\" ind1=\"#{ind1}\" ind2=\"#{ind2}\">"
-        return "<datafield tag=\"#{tag}\" ind1=\"#{ind1}\" ind2=\"#{ind2}\">"
+        "<datafield tag=\"#{tag}\" ind1=\"#{ind1}\" ind2=\"#{ind2}\">"
       end
-  
+
       def open_subfield(code)
         # return "\n    <subfield code=\"#{code}\">"
-        return "<subfield code=\"#{code}\">"
+        "<subfield code=\"#{code}\">"
       end
-  
+
       def open_controlfield(tag)
         # return "\n<controlfield tag=\"#{tag}\">"
-        return "<controlfield tag=\"#{tag}\">"
+        "<controlfield tag=\"#{tag}\">"
       end
-    
-      def encode(r, opts={})
+
+      def encode(r)
         xml = "<record>"
-      
+
         # MARCXML only allows alphanumerics or spaces in the leader
-        lead = r.leader.gsub(/[^\w|^\s]/, 'Z').encode(:xml=>:text)
+        lead = r.leader.gsub(/[^\w|^\s]/, "Z").encode(xml: :text)
 
         # MARCXML is particular about last four characters; ILSes aren't
-        lead.ljust(23, ' ')[20..23] = "4500"
+        lead.ljust(23, " ")[20..23] = "4500"
 
         # MARCXML doesn't like a space here so we need a filler character: Z
-        if (lead[6..6] == " ")
+        if lead[6..6] == " "
           lead[6..6] = "Z"
         end
-      
-        xml << "<leader>" << lead.encode(:xml => :text) << '</leader>'
+
+        xml << "<leader>" << lead.encode(xml: :text) << "</leader>"
         r.each do |f|
-          if f.class == MARC::DataField
+          if f.instance_of?(MARC::DataField)
             xml << open_datafield(f.tag, f.indicator1, f.indicator2)
             f.each do |sf|
-              xml << open_subfield(sf.code) << sf.value.encode(:xml => :text) << '</subfield>'
+              xml << open_subfield(sf.code) << sf.value.encode(xml: :text) << "</subfield>"
             end
-            xml << '</datafield>'
-          elsif f.class == MARC::ControlField
-            xml << open_controlfield(f.tag) << f.value.encode(:xml=>:text) << '</controlfield>'
+            xml << "</datafield>"
+          elsif f.instance_of?(MARC::ControlField)
+            xml << open_controlfield(f.tag) << f.value.encode(xml: :text) << "</controlfield>"
           end
         end
-        xml << '</record>'
-        return xml.force_encoding('utf-8')
+        xml << "</record>"
+        xml.force_encoding("utf-8")
       end
     end
   end

--- a/marc-fastxmlwriter.gemspec
+++ b/marc-fastxmlwriter.gemspec
@@ -1,24 +1,24 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'marc/fastxmlwriter/version'
+require "marc/fastxmlwriter/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "marc-fastxmlwriter"
-  spec.version       = Marc::FastXMLWriter::VERSION
-  spec.authors       = ["Bill Dueber"]
-  spec.email         = ["bill@dueber.com"]
-  spec.summary       = %q{Faster (but unverified) MARC-XML from a MARC Record}
-  spec.homepage      = "https://github.com/billdueber/marc-fastxmlwriter"
-  spec.license       = "MIT"
+  spec.name = "marc-fastxmlwriter"
+  spec.version = Marc::FastXMLWriter::VERSION
+  spec.authors = ["Bill Dueber"]
+  spec.email = ["bill@dueber.com"]
+  spec.summary = "Faster (but unverified) MARC-XML from a MARC Record"
+  spec.homepage = "https://github.com/billdueber/marc-fastxmlwriter"
+  spec.license = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files = `git ls-files -z`.split("\x0")
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'marc', '~>1.0'
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_dependency "marc", "~>1.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "nokogiri", "~> 1.0"
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,15 +1,14 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'marc/fastxmlwriter'
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "marc/fastxmlwriter"
 
-require 'minitest'
-require 'minitest/spec'
-require 'minitest/autorun'
-
+require "minitest"
+require "minitest/spec"
+require "minitest/autorun"
 
 def test_data_dir
-  return File.expand_path(File.join(File.dirname(__FILE__), "test_data"))
+  File.expand_path(File.join(File.dirname(__FILE__), "test_data"))
 end
 
 def test_data(relative_path)
-  return File.expand_path(File.join("test_data", relative_path), File.dirname(__FILE__))
+  File.expand_path(File.join("test_data", relative_path), File.dirname(__FILE__))
 end

--- a/test/round_trip_spec.rb
+++ b/test/round_trip_spec.rb
@@ -1,6 +1,7 @@
-require 'minitest_helper'
-require 'marc'
-require 'stringio'
+require "minitest_helper"
+require "marc"
+require "stringio"
+require "nokogiri"
 
 describe "loads" do
   it "loads the constant" do
@@ -8,19 +9,34 @@ describe "loads" do
   end
 end
 
-
-
-ROUND_TRIP_FILES = Dir.glob(test_data_dir + '/*')
+ROUND_TRIP_FILES = Dir.glob(test_data_dir + "/*")
 
 describe "round-trip tests" do
-  it "round-trips to/from xml and MARC::Record" do
+  describe "Using namespace" do
+    describe "rexml" do
+      ROUND_TRIP_FILES.each do |filename|
+        MARC::Reader.new(filename).each_with_index do |r1, i|
+          it "round-trips to/from xml and MARC::Record with namespace" do
+            use_namespace = true
+            xml = MARC::FastXMLWriter.single_record_document(r1, include_namespace: use_namespace)
+            srexml = StringIO.new(xml.dup)
+            r3 = MARC::XMLReader.new(srexml, parser: "rexml", ignore_namespace: !use_namespace).first
+            assert_equal r1, r3, "File #{filename} record #{i}, rexml with include_namespace = #{use_namespace}"
+          end
+        end
+      end
+    end
+  end
+
+  describe "nokogiri" do
     ROUND_TRIP_FILES.each do |filename|
       MARC::Reader.new(filename).each_with_index do |r1, i|
-        [false, true].each do |use_namespace|
-          xml = MARC::FastXMLWriter.single_record_document(r1, :include_namespace=>use_namespace)
-          s = StringIO.new(xml)
-          r2 = MARC::XMLReader.new(s).first
-          assert_equal r1, r2, "File #{filename} record #{i}, include_namespace = #{use_namespace}"
+        it "round-trips to/from xml and MARC::Record with namespace" do
+          use_namespace = true
+          xml = MARC::FastXMLWriter.single_record_document(r1, include_namespace: use_namespace)
+          srexml = StringIO.new(xml.dup)
+          r3 = MARC::XMLReader.new(srexml, parser: "nokogiri", ignore_namespace: !use_namespace).first
+          assert_equal r1, r3, "File #{filename} record #{i}, nokogiri with include_namespace = #{use_namespace}"
         end
       end
     end


### PR DESCRIPTION
The supposed `include_namespace` code wasn't actually using
the namespace, only defining it.

* Actually use the namespace with `xmlns=http://www.loc.gov/...`
* Add tests against rexml and nokogiri parsers for round-trip
  fidelity
* Run code through standardrb
* Bump version to 1.1.0