### PR TITLE
Allow including namespace and schema attributes on <record>

### DIFF
--- a/lib/marc/fastxmlwriter.rb
+++ b/lib/marc/fastxmlwriter.rb
@@ -6,8 +6,7 @@ module MARC
   class FastXMLWriter < MARC::XMLWriter
     XML_HEADER = '<?xml version="1.0" encoding="UTF-8"?>'
 
-    OPEN_COLLECTION = "<collection>"
-    OPEN_COLLECTION_NAMESPACE = %(<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">)
+    NS_ATTRS = %(xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd")
 
     def initialize(file, opts = {})
       super
@@ -21,9 +20,17 @@ module MARC
     class << self
       def open_collection(use_ns)
         if use_ns
-          OPEN_COLLECTION_NAMESPACE.dup
+          "<collection #{NS_ATTRS}>"
         else
-          OPEN_COLLECTION.dup
+          "<collection>"
+        end
+      end
+
+      def open_record(use_ns)
+        if use_ns
+          "<record #{NS_ATTRS}>"
+        else
+          "<record>"
         end
       end
 
@@ -49,8 +56,8 @@ module MARC
         "<controlfield tag=\"#{tag}\">"
       end
 
-      def encode(r)
-        xml = "<record>"
+      def encode(r, include_namespace: false)
+        xml = open_record(include_namespace)
 
         # MARCXML only allows alphanumerics or spaces in the leader
         lead = r.leader.gsub(/[^\w|^\s]/, "Z").encode(xml: :text)

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -6,9 +6,9 @@ require "minitest/spec"
 require "minitest/autorun"
 
 def test_data_dir
-  File.expand_path(File.join(File.dirname(__FILE__), "test_data"))
+  File.join(__dir__, "test_data")
 end
 
 def test_data(relative_path)
-  File.expand_path(File.join("test_data", relative_path), File.dirname(__FILE__))
+  File.join(__dir__, "test_data", relative_path)
 end

--- a/test/record_namespace_spec.rb
+++ b/test/record_namespace_spec.rb
@@ -1,0 +1,36 @@
+require "minitest_helper"
+require "marc"
+require "stringio"
+require "nokogiri"
+
+describe "#encode" do
+  def record
+    MARC::Reader.new(test_data("one.dat")).first
+  end
+
+  it "does not include xml declaration" do
+    refute_match(%r{<\?xml}, MARC::FastXMLWriter.encode(record))
+  end
+
+  describe "with namespace" do
+    it "includes schema location" do
+      assert_match(%r{xsi:schemaLocation}, MARC::FastXMLWriter.encode(record, include_namespace: true))
+    end
+
+    it "includes namespace declaration" do
+      assert_match(%r{xmlns}, MARC::FastXMLWriter.encode(record, include_namespace: true))
+    end
+
+    it "validates against marc21slim.xsd" do
+      xsd = Nokogiri::XML::Schema.new(File.read(File.join(__dir__, "schema", "MARC21slim.xsd")))
+      doc = Nokogiri::XML.parse(MARC::FastXMLWriter.encode(record, include_namespace: true))
+      assert xsd.validate(doc)
+    end
+  end
+
+  describe "without namespace" do
+    it "is well-formed" do
+      refute_nil Nokogiri::XML.parse(MARC::FastXMLWriter.encode(record))
+    end
+  end
+end

--- a/test/schema/MARC21slim.xsd
+++ b/test/schema/MARC21slim.xsd
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<xsd:schema targetNamespace="http://www.loc.gov/MARC21/slim" xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" xml:lang="en">
+  <xsd:annotation>
+    <xsd:documentation>
+			MARCXML: The MARC 21 XML Schema
+			Prepared by Corey Keith
+			
+				May 21, 2002 - Version 1.0  - Initial Release
+
+**********************************************
+Changes.
+
+August 4, 2003 - Version 1.1 - 
+Removed import of xml namespace and the use of xml:space="preserve" attributes on the leader and controlfields. 
+                    Whitespace preservation in these subfields is accomplished by the use of xsd:whiteSpace value="preserve"
+
+May 21, 2009  - Version 1.2 - 
+in subfieldcodeDataType  the pattern 
+                          "[\da-z!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?{}_^`~\[\]\\]{1}"
+	changed to:	
+                         "[\dA-Za-z!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?{}_^`~\[\]\\]{1}"
+    i.e "A-Z" added after "[\d" before "a-z"  to allow upper case.  This change is for consistency with the documentation.
+	
+************************************************************
+			This schema supports XML markup of MARC21 records as specified in the MARC documentation (see www.loc.gov).  It allows tags with
+			alphabetics and subfield codes that are symbols, neither of which are as yet used in  the MARC 21 communications formats, but are 
+			allowed by MARC 21 for local data.  The schema accommodates all types of MARC 21 records: bibliographic, holdings, bibliographic 
+			with embedded holdings, authority, classification, and community information.
+		</xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="record" type="recordType" nillable="true" id="record.e">
+    <xsd:annotation>
+      <xsd:documentation>record is a top level container element for all of the field elements which compose the record</xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+  <xsd:element name="collection" type="collectionType" nillable="true" id="collection.e">
+    <xsd:annotation>
+      <xsd:documentation>collection is a top level container element for 0 or many records</xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+  <xsd:complexType name="collectionType" id="collection.ct">
+    <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+      <xsd:element ref="record"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="idDataType" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="recordType" id="record.ct">
+    <xsd:sequence minOccurs="0">
+      <xsd:element name="leader" type="leaderFieldType"/>
+      <xsd:element name="controlfield" type="controlFieldType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="datafield" type="dataFieldType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="recordTypeType" use="optional"/>
+    <xsd:attribute name="id" type="idDataType" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="recordTypeType" id="type.st">
+    <xsd:restriction base="xsd:NMTOKEN">
+      <xsd:enumeration value="Bibliographic"/>
+      <xsd:enumeration value="Authority"/>
+      <xsd:enumeration value="Holdings"/>
+      <xsd:enumeration value="Classification"/>
+      <xsd:enumeration value="Community"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="leaderFieldType" id="leader.ct">
+    <xsd:annotation>
+      <xsd:documentation>MARC21 Leader, 24 bytes</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="leaderDataType">
+        <xsd:attribute name="id" type="idDataType" use="optional"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:simpleType name="leaderDataType" id="leader.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="[\d ]{5}[\dA-Za-z ]{1}[\dA-Za-z]{1}[\dA-Za-z ]{3}(2| )(2| )[\d ]{5}[\dA-Za-z ]{3}(4500|    )"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="controlFieldType" id="controlfield.ct">
+    <xsd:annotation>
+      <xsd:documentation>MARC21 Fields 001-009</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="controlDataType">
+        <xsd:attribute name="id" type="idDataType" use="optional"/>
+        <xsd:attribute name="tag" type="controltagDataType" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:simpleType name="controlDataType" id="controlfield.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="controltagDataType" id="controltag.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="00[1-9A-Za-z]{1}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="dataFieldType" id="datafield.ct">
+    <xsd:annotation>
+      <xsd:documentation>MARC21 Variable Data Fields 010-999</xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence maxOccurs="unbounded">
+      <xsd:element name="subfield" type="subfieldatafieldType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="idDataType" use="optional"/>
+    <xsd:attribute name="tag" type="tagDataType" use="required"/>
+    <xsd:attribute name="ind1" type="indicatorDataType" use="required"/>
+    <xsd:attribute name="ind2" type="indicatorDataType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="tagDataType" id="tag.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="(0([1-9A-Z][0-9A-Z])|0([1-9a-z][0-9a-z]))|(([1-9A-Z][0-9A-Z]{2})|([1-9a-z][0-9a-z]{2}))"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="indicatorDataType" id="ind.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="[\da-z ]{1}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="subfieldatafieldType" id="subfield.ct">
+    <xsd:simpleContent>
+      <xsd:extension base="subfieldDataType">
+        <xsd:attribute name="id" type="idDataType" use="optional"/>
+        <xsd:attribute name="code" type="subfieldcodeDataType" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:simpleType name="subfieldDataType" id="subfield.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="subfieldcodeDataType" id="code.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="[\dA-Za-z!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?{}_^`~\[\]\\]{1}"/>
+      <!-- "A-Z" added after "\d" May 21, 2009 -->
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="idDataType" id="id.st">
+    <xsd:restriction base="xsd:ID"/>
+  </xsd:simpleType>
+</xsd:schema>


### PR DESCRIPTION
This is useful in contexts such as OAI. OAI feeds typically wrap
individual <record> elements as children of the OAI <metadata> elements.
However, the OAI XSD for <metadata> specifies processContents="strict"
to enforce that such record elements are valid according to some XML
schema, hence the need to ensure the namespace and schema attributes are
present.

(We should probably consider moving the @billdueber version of this repository to @mlibrary, but we don't need to do that right now.)