### PR TITLE
Freeze string literal in fastxmlwriter.rb

### DIFF
--- a/lib/marc/fastxmlwriter.rb
+++ b/lib/marc/fastxmlwriter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "marc/fastxmlwriter/version"
 
 require "marc"
@@ -50,7 +51,8 @@ module MARC
       end
 
       def encode(r)
-        xml = "<record>"
+        xml = String.new
+        xml << "<record>"
 
         # MARCXML only allows alphanumerics or spaces in the leader
         lead = r.leader.gsub(/[^\w|^\s]/, "Z").encode(xml: :text)

--- a/marc-fastxmlwriter.gemspec
+++ b/marc-fastxmlwriter.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "marc", "~>1.0"
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~>13"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "nokogiri", "~> 1.0"
 end


### PR DESCRIPTION
* Unpin bundler, minitest (works fine with newer versions)
* Fixes warnings with jruby 10: jruby 10 complains:

```
/gems/jruby/3.4.0/gems/marc-fastxmlwriter-1.1.0/lib/marc/fastxmlwriter.rb:66: warning: literal string will be frozen in the future, the string was created here: /gems/jruby/3.4.0/gems/marc-fastxmlwriter-1.1.0/lib/marc/fastxmlwriter.rb:53
```

While we're at it, should we think about moving this gem to mlibrary?